### PR TITLE
add __python_compat__ string

### DIFF
--- a/status_line/__init__.py
+++ b/status_line/__init__.py
@@ -44,6 +44,7 @@ class StatusLinePlugin(octoprint.plugin.TemplatePlugin,
         ))
 
 __plugin_name__ = "Status Line"
+__python_compat__ = ">=2.7,<4"
 
 def __plugin_load__():
     global __plugin_implementation__


### PR DESCRIPTION
OctoPrint is trying to get ready for Python 3. The py3 compatibility plugin (https://plugins.octoprint.org/plugins/Python3PluginCompatibilityCheck/) thinks that StatusLine isn't Python 3 compatible. It uses metadata in the plugin repository and in the __init__.py to determine if a plugin is compatible.

2to3 and python3 both seem happy with the plugin. I think it's fine.

I've added the tag in __init__.py in this PR. Please also update the plugin repository like in https://github.com/OctoPrint/plugins.octoprint.org/pull/472.