### PR TITLE
fix pycompat string and increment version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ or manually using this URL:
 
     https://github.com/AmedeeBulle/StatusLine/archive/master.zip
 
+## Configuration
+
+If you want to move the plugin to appear at the top of the sidebar, modify the config.yaml file as follows:
+
+appearance:
+  components:
+    order:
+      sidebar:
+      - plugin_status_line
+

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "status_line"
 plugin_name = "StatusLine"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.0"
+plugin_version = "0.1.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/status_line/__init__.py
+++ b/status_line/__init__.py
@@ -44,7 +44,7 @@ class StatusLinePlugin(octoprint.plugin.TemplatePlugin,
         ))
 
 __plugin_name__ = "Status Line"
-__python_compat__ = ">=2.7,<4"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
     global __plugin_implementation__


### PR DESCRIPTION
I used a plugin to test if the plugin was compatible with Python 3. I've finally converted my OctoPrint intstallation to Python 3 and StatusLine wasn't working. This fixes that.

Also increments the version and adds a section to the README about moving the plugin to the top of the sidebar.

You can test by installing in the Plugin Manager via URL with https://github.com/aerickson/StatusLine/archive/rev_version.zip.